### PR TITLE
Add `DiscordAPI.editOriginalInteractionResponse` method

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,5 +14,7 @@ jobs:
       - uses: denoland/setup-deno@v1
       - name: Lint
         run: deno lint
+      - name: Check
+        run: deno task check
       - name: Test
         run: deno test

--- a/app_handler_test.ts
+++ b/app_handler_test.ts
@@ -10,10 +10,10 @@ import {
 } from "./discord_api_types.ts";
 import { createApp, toAPI, withErrorBehavior } from "./app_handler.ts";
 import { FakeDiscordAPI } from "./fake_discord_api.ts";
-import { permissions } from "./examples/permissions.ts";
+import { permissionsSchema } from "./examples/permissions.ts";
 
 Deno.test("toAPI", () => {
-  const actual = toAPI(permissions);
+  const actual = toAPI(permissionsSchema);
   const expected: RESTPostAPIApplicationCommandsJSONBody = {
     type: ApplicationCommandType.ChatInput,
     name: "permissions",
@@ -135,10 +135,10 @@ Deno.test("withErrorBehavior", async () => {
 });
 
 Deno.test("createApp handles valid interaction", async () => {
-  const handleInteraction = await createApp({
-    schema: permissions,
+  const permissions = await createApp({
+    schema: permissionsSchema,
     applicationID: "your_application_id",
-    register: { token: "your_bot_token" },
+    token: "your_bot_token",
     publicKey: "your_public_key",
     api: new FakeDiscordAPI(),
   }, {
@@ -165,116 +165,116 @@ Deno.test("createApp handles valid interaction", async () => {
     },
   });
   const requestJSON = {
-    "app_permissions": "311296",
-    "application_id": "your_application_id",
-    "channel": {
-      "default_thread_rate_limit_per_user": 0,
-      "flags": 0,
-      "guild_id": "your_guild_id",
-      "icon_emoji": null,
-      "id": "your_discord_channel_id",
-      "last_message_id": "1178796255749623972",
-      "last_pin_timestamp": "2023-09-27T03:18:20+00:00",
-      "name": "🦕to-do-ethan",
-      "nsfw": false,
-      "parent_id": "912816172616024176",
-      "permissions": "562949953421311",
-      "position": 8,
-      "rate_limit_per_user": 0,
-      "theme_color": null,
-      "topic": null,
-      "type": 0,
+    app_permissions: 311296,
+    application_id: "your_application_id",
+    channel: {
+      default_thread_rate_limit_per_user: 0,
+      flags: 0,
+      guild_id: "your_guild_id",
+      icon_emoji: null,
+      id: "your_discord_channel_id",
+      last_message_id: "1178796255749623972",
+      last_pin_timestamp: "2023-09-27T03:18:20+00:00",
+      name: "🦕to-do-ethan",
+      nsfw: false,
+      parent_id: "912816172616024176",
+      permissions: "562949953421311",
+      position: 8,
+      rate_limit_per_user: 0,
+      theme_color: null,
+      topic: null,
+      type: 0,
     },
-    "channel_id": "your_discord_channel_id",
-    "data": {
-      "id": "1178782909231005757",
-      "name": "permissions",
-      "options": [
+    channel_id: "your_discord_channel_id",
+    data: {
+      id: "1178782909231005757",
+      name: "permissions",
+      options: [
         {
-          "name": "user",
-          "options": [
+          name: "user",
+          options: [
             {
-              "name": "get",
-              "options": [
+              name: "get",
+              options: [
                 {
-                  "name": "user",
-                  "type": 6,
-                  "value": "your_discord_user_id",
+                  name: "user",
+                  type: 6,
+                  value: "your_discord_user_id",
                 },
               ],
-              "type": 1,
+              type: 1,
             },
           ],
-          "type": 2,
+          type: 2,
         },
       ],
-      "resolved": {
-        "members": {
-          "your_discord_user_id": {
-            "avatar": "6a0c1f0e9899ff54357ab49bf1492972",
-            "communication_disabled_until": null,
-            "flags": 0,
-            "joined_at": "2022-10-07T20:09:47.088000+00:00",
-            "nick": "etok.codes",
-            "pending": false,
-            "permissions": "562949953421311",
-            "premium_since": null,
-            "roles": ["1006798385459757096"],
-            "unusual_dm_activity_until": null,
+      resolved: {
+        members: {
+          your_discord_user_id: {
+            avatar: "6a0c1f0e9899ff54357ab49bf1492972",
+            communication_disabled_until: null,
+            flags: 0,
+            joined_at: "2022-10-07T20:09:47.088000+00:00",
+            nick: "etok.codes",
+            pending: false,
+            permissions: "562949953421311",
+            premium_since: null,
+            roles: ["1006798385459757096"],
+            unusual_dm_activity_until: null,
           },
         },
-        "users": {
-          "your_discord_user_id": {
-            "avatar": "35bc87750c2f4ab1886b6ed8a199654a",
-            "avatar_decoration_data": null,
-            "discriminator": "0",
-            "global_name": "EthanThatOneKid",
-            "id": "your_discord_user_id",
-            "public_flags": 4194432,
-            "username": "ethanthatonekid",
+        users: {
+          your_discord_user_id: {
+            avatar: "35bc87750c2f4ab1886b6ed8a199654a",
+            avatar_decoration_data: null,
+            discriminator: "0",
+            global_name: "EthanThatOneKid",
+            id: "your_discord_user_id",
+            public_flags: 4194432,
+            username: "ethanthatonekid",
           },
         },
       },
-      "type": 1,
+      type: 1,
     },
-    "entitlement_sku_ids": [],
-    "entitlements": [],
-    "guild": {
-      "features": ["SOUNDBOARD"],
-      "id": "your_guild_id",
-      "locale": "en-US",
+    entitlement_sku_ids: [],
+    entitlements: [],
+    guild: {
+      features: ["SOUNDBOARD"],
+      id: "your_guild_id",
+      locale: "en-US",
     },
-    "guild_id": "your_guild_id",
-    "guild_locale": "en-US",
-    "id": "your_interaction_id",
-    "locale": "en-US",
-    "member": {
-      "avatar": "6a0c1f0e9899ff54357ab49bf1492972",
-      "communication_disabled_until": null,
-      "deaf": false,
-      "flags": 0,
-      "joined_at": "2022-10-07T20:09:47.088000+00:00",
-      "mute": false,
-      "nick": "etok.codes",
-      "pending": false,
-      "permissions": "562949953421311",
-      "premium_since": null,
-      "roles": ["1006798385459757096"],
-      "unusual_dm_activity_until": null,
-      "user": {
-        "avatar": "35bc87750c2f4ab1886b6ed8a199654a",
-        "avatar_decoration_data": null,
-        "discriminator": "0",
-        "global_name": "EthanThatOneKid",
-        "id": "your_discord_user_id",
-        "public_flags": 4194432,
-        "username": "ethanthatonekid",
+    guild_id: "your_guild_id",
+    guild_locale: "en-US",
+    id: "your_interaction_id",
+    locale: "en-US",
+    member: {
+      avatar: "6a0c1f0e9899ff54357ab49bf1492972",
+      communication_disabled_until: null,
+      deaf: false,
+      flags: 0,
+      joined_at: "2022-10-07T20:09:47.088000+00:00",
+      mute: false,
+      nick: "etok.codes",
+      pending: false,
+      permissions: "562949953421311",
+      premium_since: null,
+      roles: ["1006798385459757096"],
+      unusual_dm_activity_until: null,
+      user: {
+        avatar: "35bc87750c2f4ab1886b6ed8a199654a",
+        avatar_decoration_data: null,
+        discriminator: "0",
+        global_name: "EthanThatOneKid",
+        id: "your_discord_user_id",
+        public_flags: 4194432,
+        username: "ethanthatonekid",
       },
     },
-    "token": "your_interaction_token",
-    "type": 2,
-    "version": 1,
-  } as const;
+    token: "your_interaction_token",
+    type: 2,
+    version: 1,
+  };
   const request = new Request(
     "https://example.com",
     {
@@ -283,7 +283,7 @@ Deno.test("createApp handles valid interaction", async () => {
       body: JSON.stringify(requestJSON),
     },
   );
-  const response = await handleInteraction(request);
+  const response = await permissions(request);
   const actual = await response.json() as APIInteractionResponse;
   const expected = {
     type: InteractionResponseType.ChannelMessageWithSource,

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,5 +7,8 @@
     "discord-api-types": "npm:discord-api-types@0.37.79/v10",
     "tweetnacl": "npm:tweetnacl@^1.0.3",
     "app/": "./"
+  },
+  "tasks": {
+    "check": "deno check ./mod.ts ./examples/*.ts"
   }
 }

--- a/discord_api.ts
+++ b/discord_api.ts
@@ -29,6 +29,43 @@ export function makeRegisterCommandsURL(
 }
 
 /**
+ * InviteOptions are the options for the invite URL.
+ */
+export interface InviteOptions {
+  /**
+   * scopes are the OAuth2 scopes.
+   */
+  scopes?: string[];
+
+  /**
+   * permissions are the permissions for the application command.
+   */
+  permissions?: string[];
+}
+
+/**
+ * makeInviteURL creates an invite URL for the application command.
+ */
+export function makeInviteURL(
+  clientID: string,
+  options: InviteOptions,
+): URL {
+  const inviteURL = new URL("https://discord.com/oauth2/authorize");
+  inviteURL.searchParams.set("client_id", clientID);
+  if (options.scopes !== undefined) {
+    inviteURL.searchParams.set("scope", options.scopes.join(" "));
+  }
+
+  if (options.permissions !== undefined) {
+    inviteURL.searchParams.set(
+      "permissions",
+      options.permissions.join(" "),
+    );
+  }
+  return inviteURL;
+}
+
+/**
  * RegisterApplicationCommandOptions are the options for registering a Discord
  * application command.
  */
@@ -170,8 +207,10 @@ export function makeEditOriginalInteractionResponseURL(
   clientID: string,
   interactionToken: string,
   base = DISCORD_API_URL,
-) {
-  return `${base}/webhooks/${clientID}/${interactionToken}/messages/@original`;
+): URL {
+  return new URL(
+    `${base}/webhooks/${clientID}/${interactionToken}/messages/@original`,
+  );
 }
 
 /**

--- a/discord_api.ts
+++ b/discord_api.ts
@@ -164,34 +164,133 @@ export async function verify(options: VerifyOptions): Promise<VerifiedRequest> {
 }
 
 /**
- * DiscordAPIInterface is the interface for the Discord API client.
+ * makeEditOriginalInteractionResponseURL makes the URL to edit the original interaction response.
  */
-export interface DiscordAPIInterface {
+export function makeEditOriginalInteractionResponseURL(
+  clientID: string,
+  interactionToken: string,
+  base = DISCORD_API_URL,
+) {
+  return `${base}/webhooks/${clientID}/${interactionToken}/messages/@original`;
+}
+
+/**
+ * EditOriginalInteractionResponseOptions is the initialization to edit the original interaction response.
+ */
+export interface EditOriginalInteractionResponseOptions {
   /**
-   * registerApplicationCommand registers a Discord application command.
+   * applicationID is the ID of the Discord application.
    */
-  registerApplicationCommand(
-    options: RegisterApplicationCommandOptions,
-  ): Promise<void>;
+  applicationID: string;
 
   /**
-   * verify verifies whether the request is coming from Discord.
+   * token is the token of the Discord bot.
    */
-  verify(options: VerifyOptions): Promise<VerifiedRequest>;
+  token: string;
+
+  /**
+   * interactionToken is the interaction token.
+   */
+  interactionToken: string;
+
+  /**
+   * content is the content to edit.
+   */
+  content: string;
 }
+
+/**
+ * editOriginalInteractionResponse edits the original interaction response.
+ */
+export async function editOriginalInteractionResponse(
+  options: EditOriginalInteractionResponseOptions,
+): Promise<void> {
+  const url = makeEditOriginalInteractionResponseURL(
+    options.applicationID,
+    options.interactionToken,
+  );
+  const response = await fetch(url, {
+    method: "PATCH",
+    headers: new Headers([["Content-Type", "application/json"]]),
+    body: JSON.stringify({ content: options.content }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to edit original interaction response: ${response.status} ${response.statusText}`,
+    );
+  }
+}
+
+/**
+ * Credentials are the credentials for the Discord API.
+ */
+export interface Credentials {
+  /**
+   * applicationID is the ID of the Discord application.
+   */
+  applicationID: string;
+
+  /**
+   * token is the token of the Discord bot.
+   */
+  token: string;
+
+  /**
+   * publicKey is the public key of the Discord application.
+   */
+  publicKey: string;
+}
+
+/**
+ * OmitCredentials is a bag of options excluding the credentials.
+ */
+export type OmitCredentials<T> = Omit<T, keyof Credentials>;
 
 /**
  * DiscordAPI is the Discord API client.
  */
-export class DiscordAPI implements DiscordAPIInterface {
-  registerApplicationCommand(
-    options: RegisterApplicationCommandOptions,
+export class DiscordAPI {
+  public constructor(private readonly credentials?: Credentials) {}
+
+  public registerApplicationCommand(
+    options: OmitCredentials<RegisterApplicationCommandOptions>,
   ): Promise<void> {
-    return registerApplicationCommand(options);
+    if (this.credentials === undefined) {
+      throw new Error("Credentials are required");
+    }
+
+    return registerApplicationCommand({
+      applicationID: this.credentials.applicationID,
+      token: this.credentials.token,
+      ...options,
+    });
   }
 
-  verify(options: VerifyOptions): Promise<VerifiedRequest> {
-    return verify(options);
+  public verify(
+    options: OmitCredentials<VerifyOptions>,
+  ): Promise<VerifiedRequest> {
+    if (this.credentials === undefined) {
+      throw new Error("Credentials are required");
+    }
+
+    return verify({
+      publicKey: this.credentials.publicKey,
+      ...options,
+    });
+  }
+
+  public editOriginalInteractionResponse(
+    options: OmitCredentials<EditOriginalInteractionResponseOptions>,
+  ): Promise<void> {
+    if (this.credentials === undefined) {
+      throw new Error("Credentials are required");
+    }
+
+    return editOriginalInteractionResponse({
+      applicationID: this.credentials.applicationID,
+      token: this.credentials.token,
+      ...options,
+    });
   }
 }
 

--- a/examples/blep.ts
+++ b/examples/blep.ts
@@ -42,8 +42,9 @@ if (import.meta.main) {
       schema: blepSchema,
       applicationID: Deno.env.get("DISCORD_APPLICATION_ID")!,
       publicKey: Deno.env.get("DISCORD_PUBLIC_KEY")!,
-      register: { token: Deno.env.get("DISCORD_TOKEN")! },
+      token: Deno.env.get("DISCORD_TOKEN")!,
       invite: { path: "/invite", scopes: ["applications.commands"] },
+      register: true,
     },
     (interaction) => {
       const animal = interaction.data.parsedOptions.animal; // "animal_dog" | "animal_cat" | "animal_penguin"

--- a/examples/bookmark.ts
+++ b/examples/bookmark.ts
@@ -19,8 +19,9 @@ if (import.meta.main) {
       schema: bookmarkSchema,
       applicationID: Deno.env.get("DISCORD_APPLICATION_ID")!,
       publicKey: Deno.env.get("DISCORD_PUBLIC_KEY")!,
-      register: { token: Deno.env.get("DISCORD_TOKEN")! },
+      token: Deno.env.get("DISCORD_TOKEN")!,
       invite: { path: "/invite", scopes: ["applications.commands"] },
+      register: true,
     },
     (interaction) => {
       const message =

--- a/examples/high_five.ts
+++ b/examples/high_five.ts
@@ -19,8 +19,9 @@ if (import.meta.main) {
       schema: highFiveSchema,
       applicationID: Deno.env.get("DISCORD_APPLICATION_ID")!,
       publicKey: Deno.env.get("DISCORD_PUBLIC_KEY")!,
-      register: { token: Deno.env.get("DISCORD_TOKEN")! },
+      token: Deno.env.get("DISCORD_TOKEN")!,
       invite: { path: "/invite", scopes: ["applications.commands"] },
+      register: true,
     },
     (interaction) => {
       const targetUser =

--- a/examples/permissions.ts
+++ b/examples/permissions.ts
@@ -6,13 +6,13 @@ import {
 } from "app/mod.ts";
 
 /**
- * permissions is a `@discord-applications/app` schema modeled after the example in the
+ * permissionsSchema is a `@discord-applications/app` schema modeled after the example in the
  * official Discord API reference documentation.
  *
  * @see
  * https://discord.com/developers/docs/interactions/application-commands#example-walkthrough
  */
-export const permissions = {
+export const permissionsSchema = {
   chatInput: {
     name: "permissions",
     description: "Get or edit permissions for a user or a role",
@@ -97,13 +97,14 @@ export const permissions = {
 
 if (import.meta.main) {
   // Create the Discord application.
-  const handleInteraction = await createApp(
+  const permissions = await createApp(
     {
-      schema: permissions,
+      schema: permissionsSchema,
       applicationID: Deno.env.get("DISCORD_APPLICATION_ID")!,
       publicKey: Deno.env.get("DISCORD_PUBLIC_KEY")!,
-      register: { token: Deno.env.get("DISCORD_TOKEN")! },
+      token: Deno.env.get("DISCORD_TOKEN")!,
       invite: { path: "/invite", scopes: ["applications.commands"] },
+      register: true,
     },
     {
       user: {
@@ -131,5 +132,5 @@ if (import.meta.main) {
   );
 
   // Start the server.
-  Deno.serve(handleInteraction);
+  Deno.serve(permissions);
 }

--- a/fake_discord_api.ts
+++ b/fake_discord_api.ts
@@ -1,5 +1,7 @@
 import type {
-  DiscordAPIInterface,
+  DiscordAPI,
+  EditOriginalInteractionResponseOptions,
+  OmitCredentials,
   RegisterApplicationCommandOptions,
   VerifyOptions,
 } from "./discord_api.ts";
@@ -7,13 +9,21 @@ import type {
 /**
  * FakeDiscordAPI is a fake implementation of the DiscordAPIInterface.
  */
-export class FakeDiscordAPI implements DiscordAPIInterface {
-  async verify(options: VerifyOptions) {
+export class FakeDiscordAPI implements DiscordAPI {
+  public async verify(options: OmitCredentials<VerifyOptions>) {
     const json = await options.request.text();
     return { error: null, body: json };
   }
 
-  registerApplicationCommand(_: RegisterApplicationCommandOptions) {
+  public registerApplicationCommand(
+    _: OmitCredentials<RegisterApplicationCommandOptions>,
+  ) {
+    return Promise.resolve();
+  }
+
+  public editOriginalInteractionResponse(
+    _: OmitCredentials<EditOriginalInteractionResponseOptions>,
+  ) {
     return Promise.resolve();
   }
 }


### PR DESCRIPTION
### Changes

- Add `DiscordAPI.editOriginalInteractionResponse` method.
- Add "Check" step to check.yaml GitHub workflow.
- Introduce `Credentials` interface.